### PR TITLE
Use SQS instead of memory driver

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -29,3 +29,22 @@ logs:
     channels:
         server:
             level: info
+
+# TODO https://roadrunner.dev/docs/beep-beep-reload
+# reload:
+#   # sync interval
+#   interval: 1s
+#   # global patterns to sync
+#   patterns: [ ".php" ]
+#   # list of included for sync services
+#   services:
+#     http:
+#       # recursive search for file patterns to add
+#       recursive: true
+#       # ignored folders
+#       ignore: [ "vendor" ]
+#       # service specific file pattens to sync
+#       patterns: [ ".php", ".go", ".md" ]
+#       # directories to sync. If recursive is set to true,
+#       # recursive sync will be applied only to the directories in `dirs` section
+#       dirs: [ "." ]

--- a/app/src/Activity/RouteActivity.php
+++ b/app/src/Activity/RouteActivity.php
@@ -7,6 +7,7 @@ use Cycle\ORM\EntityManager;
 use Cycle\ORM\ORMInterface;
 use Spiral\RoadRunner\Jobs\Jobs;
 use Spiral\RoadRunner\Jobs\Queue\MemoryCreateInfo;
+use Spiral\RoadRunner\Jobs\Queue\SQSCreateInfo;
 use Spiral\TemporalBridge\Attribute\AssignWorker;
 use Temporal\Activity\ActivityInterface;
 use Temporal\Activity\ActivityMethod;
@@ -50,7 +51,8 @@ class RouteActivity
         dumprr(sprintf("New queue route `%s`", $route));
 
         try {
-            $this->jobs->create(new MemoryCreateInfo($route, $priority));
+            // $this->jobs->create(new MemoryCreateInfo($route, $priority));
+            $this->jobs->create(new SQSCreateInfo($route, $priority));
             $this->jobs->resume($route);
         } catch (\Throwable $e) {
             dumprr(sprintf("Duplicate queue route `%s`", $route));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,9 @@ services:
     networks:
       - temporal-network
     ports:
+      # REST endpoint, e.g. `curlie localhost:9324`
       - 9324:9324
+      # Stats web UI, http://localhost:9325/
       - 9325:9325
 
   # This service is similar to the "s2s-api" service in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,15 @@ services:
     ports:
       - 8088:8088
 
+  elasticmq:
+    container_name: elasticmq
+    image: softwaremill/elasticmq-native
+    networks:
+      - temporal-network
+    ports:
+      - 9324:9324
+      - 9325:9325
+
   # This service is similar to the "s2s-api" service in
   # https://github.com/stock2shop/api/blob/master/docker-compose.yml
   # Unlike stock2shop/app, which uses phusion/baseimage,


### PR DESCRIPTION
@wolfy-j @flumonion This branch makes the example use SQS instead of memory driver. Will use default SQS queue for push, and FIFO for dynamic (per channel type or ID) queues